### PR TITLE
#143342749 Redesign UI for user authentication

### DIFF
--- a/app/controllers/users.js
+++ b/app/controllers/users.js
@@ -177,7 +177,7 @@ exports.createAPI = (req, res) => {
             return res.status(500).json({ success: false, message: 'Signup Error' });
           }
           req.logIn(user, (err) => {
-            if (err){
+            if (err) {
               return res.status(500).json({ success: false, message: 'Login Error' });
             } else {
               // Login is successful, set the token
@@ -280,24 +280,24 @@ exports.user = function (req, res, next, id) {
 
 exports.Signin = (req, res) => {
   if (req.body.email && req.body.password) {
-    User.findOne({ email: req.body.email }).exec((err, User) => {
+    User.findOne({ email: req.body.email }).exec((err, user) => {
       if (err) throw err;
-      if (!User) {
-        res.status(401).json({ success: false, message: 'User email does not exists' });
-      } else if (User) {
-        const validPassword = User.authenticate(req.body.password);
+      if (!user) {
+        res.status(401).json({ success: false, message: 'Invalid username or password' });
+      } else {
+        const validPassword = user.authenticate(req.body.password);
         if (!validPassword) {
-          res.status(401).json({ success: false, message: 'invalid password' });
+          res.status(401).json({ success: false, message: 'Invalid username or password' });
         } else {
-          req.logIn(User, (err) => {
+          req.logIn(user, (err) => {
             if (err) throw err;
           });
-          const token = jwt.sign(User, secretKey);
-          res.status(200).json({ success: true, message: 'signin successfull', token });
+          const token = jwt.sign(user, secretKey);
+          res.status(200).json({ success: true, message: 'Signin successful', token });
         }
       }
     });
   } else {
-    res.status(401).json({ success: false, message: 'no email or password entered' });
+    res.status(401).json({ success: false, message: 'No email or password entered' });
   }
 };

--- a/public/css/common.css
+++ b/public/css/common.css
@@ -12,1037 +12,829 @@
   font-family: Arial;
   font-size: 20px;
   font-weight: bold;
-  vertical-align: top;
-}
-@media (max-width: 520px) {
-  .card {
-    font-size: 14px;
-    height: 115px;
-    word-wrap: break-word;
-  }
-}
-.card.how-to {
-  font-size: 1.4rem;
-}
-.card #selection-number {
-  position: absolute;
-  bottom: 1px;
-  left: 7px;
-  font-size: 18px;
-}
-.card.black {
-  background: #252525;
-  border-color: white;
-  color: white;
-}
-.card.longBlack {
-  background: #252525;
-  border-color: white;
-  color: white;
-  height: 100%;
-  width: 35.5em;
-  padding-left: 2%;
-  padding-right: 2%;
-}
-.card.smallest {
-  font-size: 0.750em;
-}
-@media (max-width: 520px) {
+  vertical-align: top; }
+  @media (max-width: 520px) {
+    .card {
+      font-size: 14px;
+      height: 115px;
+      word-wrap: break-word; } }
+  .card.how-to {
+    font-size: 1.4rem; }
+  .card #selection-number {
+    position: absolute;
+    bottom: 1px;
+    left: 7px;
+    font-size: 18px; }
+  .card.black {
+    background: #252525;
+    border-color: white;
+    color: white; }
+  .card.longBlack {
+    background: #252525;
+    border-color: white;
+    color: white;
+    height: 100%;
+    width: 35.5em;
+    padding-left: 2%;
+    padding-right: 2%; }
   .card.smallest {
-    font-size: 10px;
-  }
-}
-.card u {
-  position: relative;
-  content: '';
-  display: inline-block;
-  width: 25%;
-  text-decoration: none;
-  height: 1em;
-  border-bottom: 0.125em solid white;
-  margin-bottom: -0.125em;
-}
-.card u .small {
-  width: 25%;
-}
-.card u .big {
-  width: 75%;
-}
-.card u .end:after {
-  position: absolute;
-  right: -0.357em;
-  display: inline-block;
-  content: '.';
-}
+    font-size: 0.750em; }
+    @media (max-width: 520px) {
+      .card.smallest {
+        font-size: 10px; } }
+  .card u {
+    position: relative;
+    content: '';
+    display: inline-block;
+    width: 25%;
+    text-decoration: none;
+    height: 1em;
+    border-bottom: 0.125em solid white;
+    margin-bottom: -0.125em; }
+    .card u .small {
+      width: 25%; }
+    .card u .big {
+      width: 75%; }
+    .card u .end:after {
+      position: absolute;
+      right: -0.357em;
+      display: inline-block;
+      content: '.'; }
 
 html, body, .main-container, .cont, #first-section, #inner-container {
-  height: 100%;
-}
+  height: 100%; }
 
 html {
   /* IE10 Consumer Preview */
-  background-image: -ms-linear-gradient(top left, #0b394e 0%, #abce8d 100%);
+  background-image: -ms-linear-gradient(top left, #0B394E 0%, #ABCE8D 100%);
   /* Mozilla Firefox */
-  background-image: -moz-linear-gradient(top left, #0b394e 0%, #abce8d 100%);
+  background-image: -moz-linear-gradient(top left, #0B394E 0%, #ABCE8D 100%);
   /* Opera */
-  background-image: -o-linear-gradient(top left, #0b394e 0%, #abce8d 100%);
+  background-image: -o-linear-gradient(top left, #0B394E 0%, #ABCE8D 100%);
   /* Webkit (Safari/Chrome 10) */
-  background-image: -webkit-gradient(linear, left top, right bottom, color-stop(0, #0b394e), color-stop(1, #abce8d));
+  background-image: -webkit-gradient(linear, left top, right bottom, color-stop(0, #0B394E), color-stop(1, #ABCE8D));
   /* Webkit (Chrome 11+) */
-  background-image: -webkit-linear-gradient(top left, #0b394e 0%, #abce8d 100%);
+  background-image: -webkit-linear-gradient(top left, #0B394E 0%, #ABCE8D 100%);
   /* W3C Markup, IE10 Release Preview */
-  background-image: linear-gradient(to bottom right, #0b394e 0%, #abce8d 100%);
+  background-image: linear-gradient(to bottom right, #0B394E 0%, #ABCE8D 100%);
   background-attachment: fixed;
   background-repeat: no-repeat;
-  position: relative;
-}
-@media (max-width: 520px) {
-  html {
-    margin-top: 0px;
-  }
-}
+  position: relative; }
+  @media (max-width: 520px) {
+    html {
+      margin-top: 0px; } }
 
 body {
   font-family: "helvetica neue", helvetica, sans-serif;
   background: transparent;
-  margin: 10px;
-}
-@media only screen and (min-width: 521px) and (max-width: 768px) {
-  body {
-    margin: 5px;
-  }
-}
-@media (max-width: 520px) {
-  body {
-    margin: 1px;
-  }
-}
+  margin: 10px; }
+  @media only screen and (min-width: 521px) and (max-width: 768px) {
+    body {
+      margin: 5px; } }
+  @media (max-width: 520px) {
+    body {
+      margin: 1px; } }
 
 .navbar .nav > li > a.brand {
   padding-left: 20px;
-  margin-left: 0;
-}
+  margin-left: 0; }
 
 .content {
   margin-top: 50px;
-  width: 70%;
-}
+  width: 70%; }
+
+#game-alert {
+  padding-top: 15%; }
+
+.invite-list {
+  background: #d3d3d3;
+  border-radius: 2px 2px 4px 4px;
+  height: 120px;
+  overflow: scroll;
+  text-align: left; }
 
 #main-container {
-  height: 100%;
-}
-#main-container #app-container {
-  height: 100%;
-  max-width: 1200px;
-  margin: 0px auto;
-  position: relative;
-}
-#main-container #app-container #menu-container {
-  width: 100%;
-  -webkit-border-radius: 8px;
-  -moz-border-radius: 8px;
-  border-radius: 8px;
-  background: #252525;
-  margin-bottom: 10px;
-  margin-top: 5px;
-  padding: 5px;
-}
-@media (max-width: 520px) {
-  #main-container #app-container #menu-container {
-    margin-bottom: 1px;
-    margin-top: 0px;
-  }
-}
-#main-container #app-container #menu-container #logo {
-  display: inline-block;
-  margin-left: 10px;
-  font-size: 28px;
-  font-family: 'Lobster', cursive;
-}
-@media (max-width: 520px) {
-  #main-container #app-container #menu-container #logo {
-    font-size: 20px;
-  }
-}
-#main-container #app-container #menu-container #logo #first-word {
-  color: #7CE4E8;
-}
-#main-container #app-container #menu-container #logo #second-word {
-  color: #FFFFA5;
-}
-#main-container #app-container #menu-container #logo #third-word {
-  color: #FC575E;
-}
-#main-container #app-container #menu-container #abandon-game-button {
-  display: inline-block;
-  float: right;
-  border-radius: 8px;
-  -moz-border-radius: 8px;
-  -webkit-border-radius: 8px;
-  font-size: 20px;
-  font-size: 1.25rem;
-  font-weight: 400;
-  text-align: center;
-  color: white;
-  background: #C54141;
-  margin-top: 3px;
-  margin-bottom: 3px;
-  margin-right: 10px;
-  padding: 0.65em 20px;
-  width: 140px;
-  cursor: pointer;
-}
-@media (max-width: 520px) {
-  #main-container #app-container #menu-container #abandon-game-button {
-    font-size: 0.7rem;
-    margin-top: 5px;
-    margin-right: 1px;
-    padding: 5px;
-    width: 60px;
-  }
-}
-#main-container #app-container #menu-container #abandon-game-button:hover {
-  background: #F34444;
-}
-#main-container #app-container #menu-container #tweet-container {
-  float: right;
-  padding-top: 10px;
-  width: 77px;
-  margin-right: 10px;
-}
-@media (max-width: 520px) {
-  #main-container #app-container #menu-container #tweet-container {
-    float: right;
-    padding-top: 6px;
-    width: 55px;
-    overflow: hidden;
-    margin-right: 11px;
-  }
-}
-#main-container #app-container #menu-container #tweet-container .hcount .count-o {
-  display: none !important;
-  width: 0 !important;
-}
-#main-container #app-container #menu-container #tweet-container .count-0 {
-  width: 0 !important;
-}
-#main-container #app-container #menu-container #tweet-container .count-ready .count-o {
-  visibility: visible;
-  visibility: hidden !important;
-}
-#main-container #app-container #social-bar-container {
-  width: 20%;
-  height: 63%;
-  position: absolute;
-  right: 0;
-  top: 60px;
-}
-@media (max-width: 520px) {
-  #main-container #app-container #social-bar-container {
-    top: auto;
-    width: 100%;
-    height: 50px;
-    position: relative;
-    top: 0;
-    left: 0;
-  }
-}
-#main-container #app-container #social-bar-container #player-container {
-  height: 13.166667%;
-  position: relative;
-  padding-top: 4%;
-  padding-bottom: 4%;
-  min-height: 85px;
-  background: #7CE4E8;
-  margin: 0 0 6% 8%;
-  -webkit-border-radius: 8px;
-  -moz-border-radius: 8px;
-  border-radius: 8px;
-}
-@media (max-width: 520px) {
-  #main-container #app-container #social-bar-container #player-container {
-    min-height: 0;
-    display: inline-block;
-    margin: 0px .5%;
-    width: 15.5%;
-    height: 48px;
-    padding-top: 1%;
-    padding-bottom: 0;
-  }
-}
-#main-container #app-container #social-bar-container #player-container #above-czar-container {
-  height: 65%;
-  width: 100%;
-}
-@media (max-width: 520px) {
-  #main-container #app-container #social-bar-container #player-container #above-czar-container {
+  height: 100%; }
+  #main-container #app-container {
     height: 100%;
-  }
-}
-#main-container #app-container #social-bar-container #player-container #above-czar-container #avatar_ {
-  height: 100%;
-  width: 38%;
-  float: left;
-  position: relative;
-  z-index: 999;
-}
-#main-container #app-container #social-bar-container #player-container #above-czar-container #avatar_ #king {
-  position: absolute;
-  max-width: 80%;
-  bottom: 20px;
-  -webkit-transform: rotate(-18deg);
-  left: -5px;
-}
-@media only screen and (min-width: 521px) and (max-width: 768px) {
-  #main-container #app-container #social-bar-container #player-container #above-czar-container #avatar_ #king {
-    max-width: 80%;
-    bottom: 27px;
-  }
-}
-@media (max-width: 520px) {
-  #main-container #app-container #social-bar-container #player-container #above-czar-container #avatar_ #king {
-    max-width: 80%;
-    bottom: 31px;
-    left: -3px;
-  }
-}
-#main-container #app-container #social-bar-container #player-container #above-czar-container #avatar_ img {
-  width: 100%;
-  height: 140%;
-  float: left;
-  -webkit-border-radius: 8px;
-  -moz-border-radius: 8px;
-  border-radius: 8px;
-  min-width: 40px;
-  min-height: 40px;
-}
-@media only screen and (min-width: 521px) and (max-width: 768px) {
-  #main-container #app-container #social-bar-container #player-container #above-czar-container #avatar_ img {
-    width: 100%;
-    height: 100%;
-    margin-left: 3px;
-  }
-}
-@media (max-width: 520px) {
-  #main-container #app-container #social-bar-container #player-container #above-czar-container #avatar_ img {
-    height: 69%;
-    width: 100%;
-    min-height: 0;
-    min-width: 0;
-    margin: 0;
-  }
-}
-#main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner {
-  float: left;
-  position: relative;
-  bottom: 8px;
-  left: 2px;
-  max-width: 62%;
-  overflow: hidden;
-}
-@media only screen and (min-width: 521px) and (max-width: 768px) {
-  #main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner {
-    left: 3px;
-  }
-}
-@media (max-width: 520px) {
-  #main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner {
-    bottom: 0;
-    left: 0;
-    height: 100%;
-    width: 60%;
-  }
-}
-#main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner #player-name h4 {
-  font-family: 'Lobster', cursive;
-  margin-bottom: 0px;
-}
-@media only screen and (min-width: 521px) and (max-width: 768px) {
-  #main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner #player-name h4 {
-    font-size: 14px;
-  }
-}
-@media (max-width: 520px) {
-  #main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner #player-name h4 {
-    font-family: 'Lobster', cursive;
-    font-size: 10px;
-    margin-top: 3px;
-    margin-bottom: 5px;
-  }
-}
-#main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner #player-score {
-  float: left;
-}
-#main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner #player-score h2 {
-  font-size: 26px;
-  margin-top: 0;
-  margin-bottom: 0;
-}
-@media only screen and (min-width: 521px) and (max-width: 768px) {
-  #main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner #player-score h2 {
-    font-size: 21px;
-  }
-}
-@media (max-width: 520px) {
-  #main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner #player-score h2 {
-    font-size: 17px;
-    line-height: 40%;
-  }
-}
-#main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner #player-star {
-  float: left;
-  margin-top: 3px;
-  margin-left: 10px;
-}
-@media only screen and (min-width: 521px) and (max-width: 768px) {
-  #main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner #player-star {
-    margin-top: 1px;
-    margin-left: 5px;
-  }
-}
-@media (max-width: 520px) {
-  #main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner #player-star {
-    display: none;
-  }
-}
-#main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner #player-star img {
-  width: 22px;
-}
-@media only screen and (min-width: 521px) and (max-width: 768px) {
-  #main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner #player-star img {
-    width: 18px;
-  }
-}
-#main-container #app-container #social-bar-container #player-container #czar-container {
-  position: absolute;
-  bottom: 0;
-  text-align: center;
-  width: 100%;
-  -webkit-border-bottom-right-radius: 8px;
-  -webkit-border-bottom-left-radius: 8px;
-  -moz-border-radius-bottomright: 8px;
-  -moz-border-radius-bottomleft: 8px;
-  border-bottom-right-radius: 8px;
-  border-bottom-left-radius: 8px;
-  background: black;
-  opacity: 0.4;
-}
-@media (max-width: 520px) {
-  #main-container #app-container #social-bar-container #player-container #czar-container {
-    overflow: auto;
-  }
-}
-#main-container #app-container #social-bar-container #player-container #czar-container #the-czar {
-  color: #fff;
-  font-weight: bold;
-  font-size: 20px;
-}
-@media (max-width: 520px) {
-  #main-container #app-container #social-bar-container #player-container #czar-container #the-czar {
-    display: none;
-  }
-}
-#main-container #app-container #gameplay-container {
-  height: 100%;
-  width: 80%;
-}
-@media (max-width: 520px) {
-  #main-container #app-container #gameplay-container {
-    width: 100%;
-    height: 91%;
-  }
-}
-#main-container #app-container #gameplay-container #upper-gameplay-container {
-  height: 28%;
-  width: 100%;
-  min-height: 220px;
-  max-height: 220px;
-}
-@media (max-width: 520px) {
-  #main-container #app-container #gameplay-container #upper-gameplay-container {
-    min-height: 140px;
-    max-height: 140px;
-  }
-}
-@media only screen and (min-width: 521px) and (max-width: 768px) {
-  #main-container #app-container #gameplay-container #upper-gameplay-container {
-    height: 16%;
-    min-height: 180px;
-    max-height: 180px;
-  }
-}
-#main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container {
-  float: left;
-  width: 19%;
-  height: 100%;
-  margin-right: 2%;
-}
-@media only screen and (min-width: 521px) and (max-width: 768px) {
-  #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container {
-    width: 21%;
-  }
-}
-@media (max-width: 520px) {
-  #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container {
-    width: 27%;
-    margin-right: 1%;
-  }
-}
-#main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #menu-container {
-  display: none;
-  text-align: center;
-  position: relative;
-  font-weight: bold;
-  -webkit-border-radius: 8px;
-  -moz-border-radius: 8px;
-  border-radius: 8px;
-  -moz-box-shadow: inset 0px 1px 0px 0px #ffffff;
-  -webkit-box-shadow: inset 0px 1px 0px 0px #ffffff;
-  box-shadow: inset 0px 1px 0px 0px #ffffff;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fcfcfc', endColorstr='#f0f0f0');
-  background-color: #D5D5D5;
-  text-indent: 0;
-  text-shadow: 1px 1px 0px #ffffff;
-  cursor: pointer;
-  height: 20%;
-  margin-bottom: 16px;
-  line-height: 20%;
-  -webkit-border-radius: 8px;
-  -moz-border-radius: 8px;
-  border-radius: 8px;
-}
-#main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #menu-container #menu-button {
-  position: absolute;
-  top: 50%;
-  left: 0;
-  right: 0;
-}
-#main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #timer-container {
-  height: 100%;
-}
-#main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #timer-container #inner-timer-container {
-  text-align: center;
-  text-align: center;
-  position: relative;
-  font-weight: bold;
-  -webkit-border-radius: 8px;
-  -moz-border-radius: 8px;
-  border-radius: 8px;
-  -moz-box-shadow: inset 0px 1px 0px 0px #ffffff;
-  -webkit-box-shadow: inset 0px 1px 0px 0px #ffffff;
-  box-shadow: inset 0px 1px 0px 0px #ffffff;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fcfcfc', endColorstr='#f0f0f0');
-  background-color: #D5D5D5;
-  text-indent: 0;
-  text-shadow: 1px 1px 0px #ffffff;
-  cursor: pointer;
-  background: #FFF;
-  text-shadow: none;
-  cursor: default;
-  border: none;
-  min-width: 85px;
-  min-height: 85px;
-  height: 100%;
-  color: #000;
-}
-#main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #timer-container #inner-timer-container #timer-status-round, #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #timer-container #inner-timer-container #timer-status-czar-choosing {
-  position: absolute;
-  left: 0;
-  right: 0;
-  padding-top: 5px;
-  padding-bottom: 8px;
-  bottom: 0;
-}
-@media only screen and (max-width: 1024px) {
-  #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #timer-container #inner-timer-container #timer-status-round, #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #timer-container #inner-timer-container #timer-status-czar-choosing {
-    font-size: 13px;
-  }
-}
-@media (max-width: 520px) {
-  #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #timer-container #inner-timer-container #timer-status-round, #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #timer-container #inner-timer-container #timer-status-czar-choosing {
-    font-size: 12px;
-  }
-}
-#main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #timer-container #inner-timer-container #time {
-  font-family: 'Lobster', cursive;
-  font-size: 110px;
-  position: absolute;
-  bottom: 25%;
-  left: 0;
-  right: 0;
-}
-@media only screen and (max-width: 1024px) {
-  #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #timer-container #inner-timer-container #time {
-    font-size: 90px;
-  }
-}
-@media (max-width: 520px) {
-  #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #timer-container #inner-timer-container #time {
-    font-size: 73px;
-  }
-}
-#main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer {
-  height: 100%;
-  float: left;
-  width: 79%;
-}
-@media only screen and (min-width: 521px) and (max-width: 768px) {
-  #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer {
-    width: 77%;
-    float: right;
-  }
-}
-@media (max-width: 520px) {
-  #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer {
-    float: left;
-    width: 71%;
-    margin-left: 1%;
-  }
-}
-#main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner {
-  width: 100%;
-  height: 100%;
-}
-#main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card {
-  width: 100%;
-  margin: 0px auto;
-  display: block;
-}
-#main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #notifications {
-  position: absolute;
-  bottom: 0;
-  right: 0;
-  padding: 10px;
-}
-#main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame {
-  width: 100%;
-  overflow: hidden;
-  height: 100%;
-  position: absolute;
-  right: 1%;
-}
-#main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #finding-players {
-  font-size: 33px;
-  text-align: center;
-  margin-top: 15px;
-}
-@media (max-width: 520px) {
-  #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #finding-players {
-    font-size: 21px;
-    margin-top: 0;
-  }
-}
-#main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #player-count-container, #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #loading-container, #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #start-game-container {
-  width: 33.333%;
-  float: left;
-  text-align: center;
-}
-#main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #player-count-container #player-count {
-  font-size: 33px;
-}
-@media (max-width: 520px) {
-  #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #player-count-container #player-count {
-    font-size: 21px;
-  }
-}
-#main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #player-count-container #the-word-players {
-  font-size: 17px;
-}
-#main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #loading-gif {
-  margin: 20px;
-}
-@media (max-width: 520px) {
-  #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #loading-gif {
-    margin-top: 5px;
-  }
-}
-#main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #start-game-container {
-  color: #333;
-}
-#main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #start-game-container #start-game-button {
-  border-radius: 8px;
-  -moz-border-radius: 5px;
-  -webkit-border-radius: 5px;
-  font-size: 20px;
-  font-size: 1.25rem;
-  font-weight: 400;
-  color: white;
-  background: #1F959C;
-  padding: 0.65em 20px;
-  margin: 10px;
-  width: 65%;
-  cursor: pointer;
-}
-@media only screen and (min-width: 521px) and (max-width: 768px) {
-  #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #start-game-container #start-game-button {
-    padding: 0.65em 2px;
-    font-size: 1.1rem;
-  }
-}
-@media (max-width: 520px) {
-  #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #start-game-container #start-game-button {
-    padding: 0.65em 1px;
-    font-size: 1rem;
-  }
-}
-#main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #start-game-container #start-game-button:hover {
-  background: #41C2CA;
-}
-#main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #game-end-info {
-  text-align: center;
-  font-size: 16px;
-}
-@media (max-width: 520px) {
-  #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #game-end-info {
-    font-size: 13px;
-  }
-}
-#main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #game-end-info .game-end-headline {
-  font-size: 24px;
-  margin-bottom: 10px;
-}
-@media (max-width: 520px) {
-  #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #game-end-info .game-end-headline {
-    font-size: 18px;
-  }
-}
-#main-container #app-container #gameplay-container #info-container {
-  width: 100%;
-  background: #252525;
-  color: white;
-  -webkit-border-radius: 8px;
-  -moz-border-radius: 8px;
-  border-radius: 8px;
-  text-align: center;
-  padding: 15px;
-  height: 50%;
-  margin-top: 10px;
-}
-@media only screen and (min-width: 521px) and (max-width: 768px) {
-  #main-container #app-container #gameplay-container #info-container {
-    padding-top: 5px;
-    height: auto;
-  }
-}
-@media (max-width: 520px) {
-  #main-container #app-container #gameplay-container #info-container {
-    width: 100%;
-    padding: 1px;
+    max-width: 1200px;
     margin: 0px auto;
-    height: 72%;
-  }
-}
-#main-container #app-container #gameplay-container #info-container #inner-info {
-  width: 90%;
-  margin: 0 5%;
-}
-#main-container #app-container #gameplay-container #info-container #inner-info #lobby-how-to-play {
-  font-size: 18px;
-  margin-top: 10px;
-}
-@media only screen and (min-width: 521px) and (max-width: 768px) {
-  #main-container #app-container #gameplay-container #info-container #inner-info #lobby-how-to-play {
-    font-size: 14px;
-  }
-}
-#main-container #app-container #gameplay-container #info-container #inner-info ol {
-  margin-top: 10px;
-  font-family: "helvetica neue", helvetica, sans-serif;
-  text-align: left;
-  font-size: 17px;
-}
-#main-container #app-container #gameplay-container #info-container #inner-info ol li {
-  list-style-type: decimal;
-  margin-bottom: 5px;
-}
-@media (max-width: 520px) {
-  #main-container #app-container #gameplay-container #info-container #inner-info ol {
-    font-size: 13px;
-    padding: 0px 10px 10px 10px;
-  }
-}
-#main-container #app-container #gameplay-container #game-end-container {
-  width: 100%;
-  background: #252525;
-  -webkit-border-radius: 8px;
-  -moz-border-radius: 8px;
-  border-radius: 8px;
-  text-align: center;
-  overflow: hidden;
-  height: 50%;
-  margin-top: 10px;
-}
-@media (max-width: 520px) {
-  #main-container #app-container #gameplay-container #game-end-container {
-    height: 65%;
-  }
-}
-#main-container #app-container #gameplay-container #game-end-container #charity-widget-container {
-  width: 40%;
-  float: left;
-}
-@media (max-width: 520px) {
-  #main-container #app-container #gameplay-container #game-end-container #charity-widget-container {
-    display: none;
-  }
-}
-#main-container #app-container #gameplay-container #game-end-container #inner-info-exit {
-  width: 60%;
-  position: relative;
-  overflow: hidden;
-  height: 100%;
-  color: white;
-  float: left;
-}
-@media (max-width: 520px) {
-  #main-container #app-container #gameplay-container #game-end-container #inner-info-exit {
-    float: none;
-    width: 80%;
-  }
-}
-#main-container #app-container #gameplay-container #game-end-container #inner-info-exit .game-end-answer-text {
-  color: white;
-}
-@media (max-width: 520px) {
-  #main-container #app-container #gameplay-container #game-end-container #inner-info-exit .game-end-answer-text {
-    padding: 6px;
-    font-size: 22px;
-  }
-}
-@media (max-width: 520px) {
-  #main-container #app-container #gameplay-container #game-end-container #inner-info-exit {
-    width: 100%;
-  }
-}
-#main-container #app-container #gameplay-container #game-end-container #inner-info-exit #inner-text-container {
-  overflow: hidden;
-  height: 100%;
-}
-@media (max-width: 520px) {
-  #main-container #app-container #gameplay-container #game-end-container #inner-info-exit #inner-text-container {
-    height: auto;
-  }
-}
-#main-container #app-container #gameplay-container #game-end-container #inner-info-exit #inner-text-container #join-new-game {
-  float: left;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fcfcfc', endColorstr='#f0f0f0');
-  background-color: white;
-  -webkit-border-top-left-radius: 8px;
-  -moz-border-radius-topleft: 8px;
-  border-top-left-radius: 8px;
-  -webkit-border-top-right-radius: 8px;
-  -moz-border-radius-topright: 8px;
-  border-top-right-radius: 8px;
-  -webkit-border-bottom-right-radius: 8px;
-  -moz-border-radius-bottomright: 8px;
-  border-bottom-right-radius: 8px;
-  -webkit-border-bottom-left-radius: 8px;
-  -moz-border-radius-bottomleft: 8px;
-  border-bottom-left-radius: 8px;
-  text-indent: 0;
-  display: inline-block;
-  color: #252525;
-  font-size: 39px;
-  font-weight: bold;
-  font-style: normal;
-  height: 100px;
-  line-height: 100px;
-  width: 200px;
-  text-decoration: none;
-  text-align: center;
-  cursor: pointer;
-  margin: 5px auto;
-  display: block;
-  width: 40%;
-  margin: 5%;
-  height: 28%;
-  font-size: 21px;
-  line-height: 155%;
-  padding-top: 5%;
-}
-#main-container #app-container #gameplay-container #game-end-container #inner-info-exit #inner-text-container #join-new-game:hover {
-  background: -webkit-gradient(linear, left top, left bottom, color-stop(0.05, #f0f0f0), color-stop(1, #ededed));
-  background: -moz-linear-gradient(center top, #f0f0f0 5%, #ededed 100%);
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#f0f0f0', endColorstr='#ededed');
-  background-color: #f0f0f0;
-  color: #4e4e4e;
-}
-#main-container #app-container #gameplay-container #game-end-container #inner-info-exit #inner-text-container #exit-match {
-  float: left;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fcfcfc', endColorstr='#f0f0f0');
-  background-color: white;
-  -webkit-border-top-left-radius: 8px;
-  -moz-border-radius-topleft: 8px;
-  border-top-left-radius: 8px;
-  -webkit-border-top-right-radius: 8px;
-  -moz-border-radius-topright: 8px;
-  border-top-right-radius: 8px;
-  -webkit-border-bottom-right-radius: 8px;
-  -moz-border-radius-bottomright: 8px;
-  border-bottom-right-radius: 8px;
-  -webkit-border-bottom-left-radius: 8px;
-  -moz-border-radius-bottomleft: 8px;
-  border-bottom-left-radius: 8px;
-  text-indent: 0;
-  display: inline-block;
-  color: #252525;
-  font-size: 39px;
-  font-weight: bold;
-  font-style: normal;
-  height: 100px;
-  line-height: 100px;
-  width: 200px;
-  text-decoration: none;
-  text-align: center;
-  cursor: pointer;
-  margin: 5px auto;
-  display: block;
-  width: 40%;
-  margin: 5%;
-  height: 28%;
-  font-size: 21px;
-  line-height: 155%;
-  padding-top: 5%;
-}
-#main-container #app-container #gameplay-container #game-end-container #inner-info-exit #inner-text-container #exit-match:hover {
-  background: -webkit-gradient(linear, left top, left bottom, color-stop(0.05, #f0f0f0), color-stop(1, #ededed));
-  background: -moz-linear-gradient(center top, #f0f0f0 5%, #ededed 100%);
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#f0f0f0', endColorstr='#ededed');
-  background-color: #f0f0f0;
-  color: #4e4e4e;
-}
-#main-container #app-container #gameplay-container #czar-blank-container {
-  color: white;
-  width: 100%;
-  background: #252525;
-  -webkit-border-radius: 8px;
-  -moz-border-radius: 8px;
-  border-radius: 8px;
-  text-align: center;
-  overflow: hidden;
-  height: 50%;
-  position: relative;
-  margin-top: 10px;
-  font-size: 30px;
-}
-@media (max-width: 520px) {
-  #main-container #app-container #gameplay-container #czar-blank-container {
-    width: 100%;
-    font-size: 16px;
-    margin: 0px auto;
-  }
-}
-#main-container #app-container #gameplay-container #czar-blank-container #czar-blank-inner {
-  position: absolute;
-  left: 10%;
-  right: 10%;
-  width: 80%;
-  height: 50px;
-  margin-top: 5%;
-}
-#main-container #app-container #gameplay-container #czar-blank-container #czar-blank-inner #smaller-text {
-  font-size: 18px;
-}
-#main-container #app-container #gameplay-container #czar-blank-container #charity-fact-container {
-  -webkit-border-radius: 8px;
-  -moz-border-radius: 8px;
-  border-radius: 8px;
-  background-color: #fff;
-  color: black;
-  position: absolute;
-  bottom: 4%;
-  margin: 0 2%;
-  width: 96%;
-  padding: 3px;
-  text-align: left;
-}
-@media (max-width: 520px) {
-  #main-container #app-container #gameplay-container #czar-blank-container #charity-fact-container {
-    height: 40%;
-    display: none;
-  }
-}
-#main-container #app-container #gameplay-container #czar-blank-container #charity-fact-container #charity-fact-tagline {
-  font-family: 'Lobster', cursive;
-  font-size: 22px;
-  margin-left: 2%;
-  margin-bottom: 3px;
-  color: #000;
-}
-@media (max-width: 520px) {
-  #main-container #app-container #gameplay-container #czar-blank-container #charity-fact-container #charity-fact-tagline {
-    font-size: 16px;
-  }
-}
-#main-container #app-container #gameplay-container #czar-blank-container #charity-fact-container #charity-fact {
-  font-size: 14px;
-  font-style: italic;
-  text-align: center;
-  width: 90%;
-  margin: 0 5% 3px 5%;
-}
-@media (max-width: 520px) {
-  #main-container #app-container #gameplay-container #czar-blank-container #charity-fact-container #charity-fact {
-    font-size: 12px;
-  }
-}
-@media (max-width: 520px) {
-  #main-container #app-container #gameplay-container #czar-blank-container #charity-fact-container #charity-logo-container {
-    position: absolute;
-    top: 1px;
-    right: 0;
-  }
-}
-#main-container #app-container #gameplay-container #czar-blank-container #charity-fact-container #charity-logo-container img {
-  float: right;
-  margin-right: 2%;
-  margin-bottom: 3px;
-}
-@media (max-width: 520px) {
-  #main-container #app-container #gameplay-container #czar-blank-container #charity-fact-container #charity-logo-container img {
-    width: 53%;
-  }
-}
-#main-container #app-container #gameplay-container #cards-container {
-  width: 100%;
-  background: #252525;
-  margin-top: 11px;
-  -webkit-border-radius: 8px;
-  -moz-border-radius: 8px;
-  border-radius: 8px;
-}
-@media (max-width: 520px) {
-  #main-container #app-container #gameplay-container #cards-container {
-    background: transparent;
-    margin-top: 2px;
-  }
-}
-#main-container #app-container #gameplay-container #cards-container #cards {
-  width: 100%;
-  height: 100%;
-  font-size: 18px;
-  padding-left: 5px;
-}
-@media (max-width: 520px) {
-  #main-container #app-container #gameplay-container #cards-container #cards {
-    background: #252525;
-    -webkit-border-radius: 8px;
-    -moz-border-radius: 8px;
-    border-radius: 8px;
-    max-height: 245px;
-  }
-}
+    position: relative; }
+    #main-container #app-container #menu-container {
+      width: 100%;
+      -webkit-border-radius: 8px;
+      -moz-border-radius: 8px;
+      border-radius: 8px;
+      background: #252525;
+      margin-bottom: 10px;
+      margin-top: 5px;
+      padding: 5px; }
+      @media (max-width: 520px) {
+        #main-container #app-container #menu-container {
+          margin-bottom: 1px;
+          margin-top: 0px; } }
+      #main-container #app-container #menu-container #logo {
+        display: inline-block;
+        margin-left: 10px;
+        font-size: 28px;
+        font-family: 'Lobster', cursive; }
+        @media (max-width: 520px) {
+          #main-container #app-container #menu-container #logo {
+            font-size: 20px; } }
+        #main-container #app-container #menu-container #logo #first-word {
+          color: #7CE4E8; }
+        #main-container #app-container #menu-container #logo #second-word {
+          color: #FFFFA5; }
+        #main-container #app-container #menu-container #logo #third-word {
+          color: #FC575E; }
+      #main-container #app-container #menu-container #abandon-game-button {
+        display: inline-block;
+        float: right;
+        border-radius: 8px;
+        -moz-border-radius: 8px;
+        -webkit-border-radius: 8px;
+        font-size: 20px;
+        font-size: 1.25rem;
+        font-weight: 400;
+        text-align: center;
+        color: white;
+        background: #C54141;
+        margin-top: 3px;
+        margin-bottom: 3px;
+        margin-right: 10px;
+        padding: 0.65em 20px;
+        width: 140px;
+        cursor: pointer; }
+        @media (max-width: 520px) {
+          #main-container #app-container #menu-container #abandon-game-button {
+            font-size: 0.7rem;
+            margin-top: 5px;
+            margin-right: 1px;
+            padding: 5px;
+            width: 60px; } }
+      #main-container #app-container #menu-container #abandon-game-button:hover {
+        background: #F34444; }
+      #main-container #app-container #menu-container #tweet-container {
+        float: right;
+        padding-top: 10px;
+        width: 77px;
+        margin-right: 10px; }
+        @media (max-width: 520px) {
+          #main-container #app-container #menu-container #tweet-container {
+            float: right;
+            padding-top: 6px;
+            width: 55px;
+            overflow: hidden;
+            margin-right: 11px; } }
+        #main-container #app-container #menu-container #tweet-container .hcount .count-o {
+          display: none !important;
+          width: 0 !important; }
+        #main-container #app-container #menu-container #tweet-container .count-0 {
+          width: 0 !important; }
+        #main-container #app-container #menu-container #tweet-container .count-ready .count-o {
+          visibility: visible;
+          visibility: hidden !important; }
+    #main-container #app-container #social-bar-container {
+      width: 20%;
+      height: 63%;
+      position: absolute;
+      right: 0;
+      top: 60px; }
+      @media (max-width: 520px) {
+        #main-container #app-container #social-bar-container {
+          top: auto;
+          width: 100%;
+          height: 50px;
+          position: relative;
+          top: 0;
+          left: 0; } }
+      #main-container #app-container #social-bar-container #player-container {
+        height: 13.166667%;
+        position: relative;
+        padding-top: 4%;
+        padding-bottom: 4%;
+        min-height: 85px;
+        background: #7CE4E8;
+        margin: 0 0 6% 8%;
+        -webkit-border-radius: 8px;
+        -moz-border-radius: 8px;
+        border-radius: 8px; }
+        @media (max-width: 520px) {
+          #main-container #app-container #social-bar-container #player-container {
+            min-height: 0;
+            display: inline-block;
+            margin: 0px .5%;
+            width: 15.5%;
+            height: 48px;
+            padding-top: 1%;
+            padding-bottom: 0; } }
+        #main-container #app-container #social-bar-container #player-container #above-czar-container {
+          height: 65%;
+          width: 100%; }
+          @media (max-width: 520px) {
+            #main-container #app-container #social-bar-container #player-container #above-czar-container {
+              height: 100%; } }
+          #main-container #app-container #social-bar-container #player-container #above-czar-container #avatar_ {
+            height: 100%;
+            width: 38%;
+            float: left;
+            position: relative;
+            z-index: 999; }
+            #main-container #app-container #social-bar-container #player-container #above-czar-container #avatar_ #king {
+              position: absolute;
+              max-width: 80%;
+              bottom: 20px;
+              -webkit-transform: rotate(-18deg);
+              left: -5px; }
+              @media only screen and (min-width: 521px) and (max-width: 768px) {
+                #main-container #app-container #social-bar-container #player-container #above-czar-container #avatar_ #king {
+                  max-width: 80%;
+                  bottom: 27px; } }
+              @media (max-width: 520px) {
+                #main-container #app-container #social-bar-container #player-container #above-czar-container #avatar_ #king {
+                  max-width: 80%;
+                  bottom: 31px;
+                  left: -3px; } }
+            #main-container #app-container #social-bar-container #player-container #above-czar-container #avatar_ img {
+              width: 100%;
+              height: 140%;
+              float: left;
+              -webkit-border-radius: 8px;
+              -moz-border-radius: 8px;
+              border-radius: 8px;
+              min-width: 40px;
+              min-height: 40px; }
+              @media only screen and (min-width: 521px) and (max-width: 768px) {
+                #main-container #app-container #social-bar-container #player-container #above-czar-container #avatar_ img {
+                  width: 100%;
+                  height: 100%;
+                  margin-left: 3px; } }
+              @media (max-width: 520px) {
+                #main-container #app-container #social-bar-container #player-container #above-czar-container #avatar_ img {
+                  height: 69%;
+                  width: 100%;
+                  min-height: 0;
+                  min-width: 0;
+                  margin: 0; } }
+          #main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner {
+            float: left;
+            position: relative;
+            bottom: 8px;
+            left: 2px;
+            max-width: 62%;
+            overflow: hidden; }
+            @media only screen and (min-width: 521px) and (max-width: 768px) {
+              #main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner {
+                left: 3px; } }
+            @media (max-width: 520px) {
+              #main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner {
+                bottom: 0;
+                left: 0;
+                height: 100%;
+                width: 60%; } }
+            #main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner #player-name h4 {
+              font-family: 'Lobster', cursive;
+              margin-bottom: 0px; }
+            @media only screen and (min-width: 521px) and (max-width: 768px) {
+              #main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner #player-name h4 {
+                font-size: 14px; } }
+            @media (max-width: 520px) {
+              #main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner #player-name h4 {
+                font-family: 'Lobster', cursive;
+                font-size: 10px;
+                margin-top: 3px;
+                margin-bottom: 5px; } }
+            #main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner #player-score {
+              float: left; }
+              #main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner #player-score h2 {
+                font-size: 26px;
+                margin-top: 0;
+                margin-bottom: 0; }
+                @media only screen and (min-width: 521px) and (max-width: 768px) {
+                  #main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner #player-score h2 {
+                    font-size: 21px; } }
+                @media (max-width: 520px) {
+                  #main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner #player-score h2 {
+                    font-size: 17px;
+                    line-height: 40%; } }
+            #main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner #player-star {
+              float: left;
+              margin-top: 3px;
+              margin-left: 10px; }
+              @media only screen and (min-width: 521px) and (max-width: 768px) {
+                #main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner #player-star {
+                  margin-top: 1px;
+                  margin-left: 5px; } }
+              @media (max-width: 520px) {
+                #main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner #player-star {
+                  display: none; } }
+              #main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner #player-star img {
+                width: 22px; }
+                @media only screen and (min-width: 521px) and (max-width: 768px) {
+                  #main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner #player-star img {
+                    width: 18px; } }
+        #main-container #app-container #social-bar-container #player-container #czar-container {
+          position: absolute;
+          bottom: 0;
+          text-align: center;
+          width: 100%;
+          -webkit-border-bottom-right-radius: 8px;
+          -webkit-border-bottom-left-radius: 8px;
+          -moz-border-radius-bottomright: 8px;
+          -moz-border-radius-bottomleft: 8px;
+          border-bottom-right-radius: 8px;
+          border-bottom-left-radius: 8px;
+          background: black;
+          opacity: 0.4; }
+          @media (max-width: 520px) {
+            #main-container #app-container #social-bar-container #player-container #czar-container {
+              overflow: auto; } }
+          #main-container #app-container #social-bar-container #player-container #czar-container #the-czar {
+            color: #fff;
+            font-weight: bold;
+            font-size: 20px; }
+            @media (max-width: 520px) {
+              #main-container #app-container #social-bar-container #player-container #czar-container #the-czar {
+                display: none; } }
+    #main-container #app-container #gameplay-container {
+      height: 100%;
+      width: 80%; }
+      @media (max-width: 520px) {
+        #main-container #app-container #gameplay-container {
+          width: 100%;
+          height: 91%; } }
+      #main-container #app-container #gameplay-container #upper-gameplay-container {
+        height: 28%;
+        width: 100%;
+        min-height: 220px;
+        max-height: 220px; }
+        @media (max-width: 520px) {
+          #main-container #app-container #gameplay-container #upper-gameplay-container {
+            min-height: 140px;
+            max-height: 140px; } }
+        @media only screen and (min-width: 521px) and (max-width: 768px) {
+          #main-container #app-container #gameplay-container #upper-gameplay-container {
+            height: 16%;
+            min-height: 180px;
+            max-height: 180px; } }
+        #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container {
+          float: left;
+          width: 19%;
+          height: 100%;
+          margin-right: 2%; }
+          @media only screen and (min-width: 521px) and (max-width: 768px) {
+            #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container {
+              width: 21%; } }
+          @media (max-width: 520px) {
+            #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container {
+              width: 27%;
+              margin-right: 1%; } }
+          #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #menu-container {
+            display: none;
+            text-align: center;
+            position: relative;
+            font-weight: bold;
+            -webkit-border-radius: 8px;
+            -moz-border-radius: 8px;
+            border-radius: 8px;
+            -moz-box-shadow: inset 0px 1px 0px 0px #ffffff;
+            -webkit-box-shadow: inset 0px 1px 0px 0px #ffffff;
+            box-shadow: inset 0px 1px 0px 0px #ffffff;
+            filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fcfcfc', endColorstr='#f0f0f0');
+            background-color: #D5D5D5;
+            text-indent: 0;
+            text-shadow: 1px 1px 0px #ffffff;
+            cursor: pointer;
+            height: 20%;
+            margin-bottom: 16px;
+            line-height: 20%;
+            -webkit-border-radius: 8px;
+            -moz-border-radius: 8px;
+            border-radius: 8px; }
+            #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #menu-container #menu-button {
+              position: absolute;
+              top: 50%;
+              left: 0;
+              right: 0; }
+          #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #timer-container {
+            height: 100%; }
+            #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #timer-container #inner-timer-container {
+              text-align: center;
+              text-align: center;
+              position: relative;
+              font-weight: bold;
+              -webkit-border-radius: 8px;
+              -moz-border-radius: 8px;
+              border-radius: 8px;
+              -moz-box-shadow: inset 0px 1px 0px 0px #ffffff;
+              -webkit-box-shadow: inset 0px 1px 0px 0px #ffffff;
+              box-shadow: inset 0px 1px 0px 0px #ffffff;
+              filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fcfcfc', endColorstr='#f0f0f0');
+              background-color: #D5D5D5;
+              text-indent: 0;
+              text-shadow: 1px 1px 0px #ffffff;
+              cursor: pointer;
+              background: #FFF;
+              text-shadow: none;
+              cursor: default;
+              border: none;
+              min-width: 85px;
+              min-height: 85px;
+              height: 100%;
+              color: #000; }
+              #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #timer-container #inner-timer-container #timer-status-round, #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #timer-container #inner-timer-container #timer-status-czar-choosing {
+                position: absolute;
+                left: 0;
+                right: 0;
+                padding-top: 5px;
+                padding-bottom: 8px;
+                bottom: 0; }
+                @media only screen and (max-width: 1024px) {
+                  #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #timer-container #inner-timer-container #timer-status-round, #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #timer-container #inner-timer-container #timer-status-czar-choosing {
+                    font-size: 13px; } }
+                @media (max-width: 520px) {
+                  #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #timer-container #inner-timer-container #timer-status-round, #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #timer-container #inner-timer-container #timer-status-czar-choosing {
+                    font-size: 12px; } }
+              #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #timer-container #inner-timer-container #time {
+                font-family: 'Lobster', cursive;
+                font-size: 110px;
+                position: absolute;
+                bottom: 25%;
+                left: 0;
+                right: 0; }
+                @media only screen and (max-width: 1024px) {
+                  #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #timer-container #inner-timer-container #time {
+                    font-size: 90px; } }
+                @media (max-width: 520px) {
+                  #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #timer-container #inner-timer-container #time {
+                    font-size: 73px; } }
+        #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer {
+          height: 100%;
+          float: left;
+          width: 79%; }
+          @media only screen and (min-width: 521px) and (max-width: 768px) {
+            #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer {
+              width: 77%;
+              float: right; } }
+          @media (max-width: 520px) {
+            #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer {
+              float: left;
+              width: 71%;
+              margin-left: 1%; } }
+          #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner {
+            width: 100%;
+            height: 100%; }
+            #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card {
+              width: 100%;
+              margin: 0px auto;
+              display: block; }
+              #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #notifications {
+                position: absolute;
+                bottom: 0;
+                right: 0;
+                padding: 10px; }
+              #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame {
+                width: 100%;
+                overflow: hidden;
+                height: 100%;
+                position: absolute;
+                right: 1%; }
+                #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #finding-players {
+                  font-size: 33px;
+                  text-align: center;
+                  margin-top: 15px; }
+                  @media (max-width: 520px) {
+                    #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #finding-players {
+                      font-size: 21px;
+                      margin-top: 0; } }
+                #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #player-count-container, #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #loading-container, #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #start-game-container {
+                  width: 33.333%;
+                  float: left;
+                  text-align: center; }
+                #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #player-count-container #player-count {
+                  font-size: 33px; }
+                  @media (max-width: 520px) {
+                    #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #player-count-container #player-count {
+                      font-size: 21px; } }
+                #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #player-count-container #the-word-players {
+                  font-size: 17px; }
+                #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #loading-gif {
+                  margin: 20px; }
+                  @media (max-width: 520px) {
+                    #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #loading-gif {
+                      margin-top: 5px; } }
+                #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #start-game-container {
+                  color: #333; }
+                  #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #start-game-container #start-game-button {
+                    border-radius: 8px;
+                    -moz-border-radius: 5px;
+                    -webkit-border-radius: 5px;
+                    font-size: 20px;
+                    font-size: 1.25rem;
+                    font-weight: 400;
+                    color: white;
+                    background: #1F959C;
+                    padding: 0.65em 20px;
+                    margin: 10px;
+                    width: 65%;
+                    cursor: pointer; }
+                    @media only screen and (min-width: 521px) and (max-width: 768px) {
+                      #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #start-game-container #start-game-button {
+                        padding: 0.65em 2px;
+                        font-size: 1.1rem; } }
+                    @media (max-width: 520px) {
+                      #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #start-game-container #start-game-button {
+                        padding: 0.65em 1px;
+                        font-size: 1rem; } }
+                  #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #start-game-container #start-game-button:hover {
+                    background: #41C2CA; }
+              #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #game-end-info {
+                text-align: center;
+                font-size: 16px; }
+                @media (max-width: 520px) {
+                  #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #game-end-info {
+                    font-size: 13px; } }
+                #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #game-end-info .game-end-headline {
+                  font-size: 24px;
+                  margin-bottom: 10px; }
+                  @media (max-width: 520px) {
+                    #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #game-end-info .game-end-headline {
+                      font-size: 18px; } }
+      #main-container #app-container #gameplay-container #info-container {
+        width: 100%;
+        background: #252525;
+        color: white;
+        -webkit-border-radius: 8px;
+        -moz-border-radius: 8px;
+        border-radius: 8px;
+        text-align: center;
+        padding: 15px;
+        height: 50%;
+        margin-top: 10px; }
+        @media only screen and (min-width: 521px) and (max-width: 768px) {
+          #main-container #app-container #gameplay-container #info-container {
+            padding-top: 5px;
+            height: auto; } }
+        @media (max-width: 520px) {
+          #main-container #app-container #gameplay-container #info-container {
+            width: 100%;
+            padding: 1px;
+            margin: 0px auto;
+            height: 72%; } }
+        #main-container #app-container #gameplay-container #info-container #inner-info {
+          width: 90%;
+          margin: 0 5%; }
+          #main-container #app-container #gameplay-container #info-container #inner-info #lobby-how-to-play {
+            font-size: 18px;
+            margin-top: 10px; }
+            @media only screen and (min-width: 521px) and (max-width: 768px) {
+              #main-container #app-container #gameplay-container #info-container #inner-info #lobby-how-to-play {
+                font-size: 14px; } }
+          #main-container #app-container #gameplay-container #info-container #inner-info ol {
+            margin-top: 10px;
+            font-family: "helvetica neue", helvetica, sans-serif;
+            text-align: left;
+            font-size: 17px; }
+            #main-container #app-container #gameplay-container #info-container #inner-info ol li {
+              list-style-type: decimal;
+              margin-bottom: 5px; }
+            @media (max-width: 520px) {
+              #main-container #app-container #gameplay-container #info-container #inner-info ol {
+                font-size: 13px;
+                padding: 0px 10px 10px 10px; } }
+      #main-container #app-container #gameplay-container #game-end-container {
+        width: 100%;
+        background: #252525;
+        -webkit-border-radius: 8px;
+        -moz-border-radius: 8px;
+        border-radius: 8px;
+        text-align: center;
+        overflow: hidden;
+        height: 50%;
+        margin-top: 10px; }
+        @media (max-width: 520px) {
+          #main-container #app-container #gameplay-container #game-end-container {
+            height: 65%; } }
+        #main-container #app-container #gameplay-container #game-end-container #charity-widget-container {
+          width: 40%;
+          float: left; }
+          @media (max-width: 520px) {
+            #main-container #app-container #gameplay-container #game-end-container #charity-widget-container {
+              display: none; } }
+        #main-container #app-container #gameplay-container #game-end-container #inner-info-exit {
+          width: 60%;
+          position: relative;
+          overflow: hidden;
+          height: 100%;
+          color: white;
+          float: left; }
+          @media (max-width: 520px) {
+            #main-container #app-container #gameplay-container #game-end-container #inner-info-exit {
+              float: none;
+              width: 80%; } }
+          #main-container #app-container #gameplay-container #game-end-container #inner-info-exit .game-end-answer-text {
+            color: white; }
+            @media (max-width: 520px) {
+              #main-container #app-container #gameplay-container #game-end-container #inner-info-exit .game-end-answer-text {
+                padding: 6px;
+                font-size: 22px; } }
+          @media (max-width: 520px) {
+            #main-container #app-container #gameplay-container #game-end-container #inner-info-exit {
+              width: 100%; } }
+          #main-container #app-container #gameplay-container #game-end-container #inner-info-exit #inner-text-container {
+            overflow: hidden;
+            height: 100%; }
+            @media (max-width: 520px) {
+              #main-container #app-container #gameplay-container #game-end-container #inner-info-exit #inner-text-container {
+                height: auto; } }
+            #main-container #app-container #gameplay-container #game-end-container #inner-info-exit #inner-text-container #join-new-game {
+              float: left;
+              filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fcfcfc', endColorstr='#f0f0f0');
+              background-color: white;
+              -webkit-border-top-left-radius: 8px;
+              -moz-border-radius-topleft: 8px;
+              border-top-left-radius: 8px;
+              -webkit-border-top-right-radius: 8px;
+              -moz-border-radius-topright: 8px;
+              border-top-right-radius: 8px;
+              -webkit-border-bottom-right-radius: 8px;
+              -moz-border-radius-bottomright: 8px;
+              border-bottom-right-radius: 8px;
+              -webkit-border-bottom-left-radius: 8px;
+              -moz-border-radius-bottomleft: 8px;
+              border-bottom-left-radius: 8px;
+              text-indent: 0;
+              display: inline-block;
+              color: #252525;
+              font-size: 39px;
+              font-weight: bold;
+              font-style: normal;
+              height: 100px;
+              line-height: 100px;
+              width: 200px;
+              text-decoration: none;
+              text-align: center;
+              cursor: pointer;
+              margin: 5px auto;
+              display: block;
+              width: 40%;
+              margin: 5%;
+              height: 28%;
+              font-size: 21px;
+              line-height: 155%;
+              padding-top: 5%; }
+              #main-container #app-container #gameplay-container #game-end-container #inner-info-exit #inner-text-container #join-new-game:hover {
+                background: -webkit-gradient(linear, left top, left bottom, color-stop(0.05, #f0f0f0), color-stop(1, #ededed));
+                background: -moz-linear-gradient(center top, #f0f0f0 5%, #ededed 100%);
+                filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#f0f0f0', endColorstr='#ededed');
+                background-color: #f0f0f0;
+                color: #4e4e4e; }
+            #main-container #app-container #gameplay-container #game-end-container #inner-info-exit #inner-text-container #exit-match {
+              float: left;
+              filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fcfcfc', endColorstr='#f0f0f0');
+              background-color: white;
+              -webkit-border-top-left-radius: 8px;
+              -moz-border-radius-topleft: 8px;
+              border-top-left-radius: 8px;
+              -webkit-border-top-right-radius: 8px;
+              -moz-border-radius-topright: 8px;
+              border-top-right-radius: 8px;
+              -webkit-border-bottom-right-radius: 8px;
+              -moz-border-radius-bottomright: 8px;
+              border-bottom-right-radius: 8px;
+              -webkit-border-bottom-left-radius: 8px;
+              -moz-border-radius-bottomleft: 8px;
+              border-bottom-left-radius: 8px;
+              text-indent: 0;
+              display: inline-block;
+              color: #252525;
+              font-size: 39px;
+              font-weight: bold;
+              font-style: normal;
+              height: 100px;
+              line-height: 100px;
+              width: 200px;
+              text-decoration: none;
+              text-align: center;
+              cursor: pointer;
+              margin: 5px auto;
+              display: block;
+              width: 40%;
+              margin: 5%;
+              height: 28%;
+              font-size: 21px;
+              line-height: 155%;
+              padding-top: 5%; }
+              #main-container #app-container #gameplay-container #game-end-container #inner-info-exit #inner-text-container #exit-match:hover {
+                background: -webkit-gradient(linear, left top, left bottom, color-stop(0.05, #f0f0f0), color-stop(1, #ededed));
+                background: -moz-linear-gradient(center top, #f0f0f0 5%, #ededed 100%);
+                filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#f0f0f0', endColorstr='#ededed');
+                background-color: #f0f0f0;
+                color: #4e4e4e; }
+      #main-container #app-container #gameplay-container #czar-blank-container {
+        color: white;
+        width: 100%;
+        background: #252525;
+        -webkit-border-radius: 8px;
+        -moz-border-radius: 8px;
+        border-radius: 8px;
+        text-align: center;
+        overflow: hidden;
+        height: 50%;
+        position: relative;
+        margin-top: 10px;
+        font-size: 30px; }
+        @media (max-width: 520px) {
+          #main-container #app-container #gameplay-container #czar-blank-container {
+            width: 100%;
+            font-size: 16px;
+            margin: 0px auto; } }
+        #main-container #app-container #gameplay-container #czar-blank-container #czar-blank-inner {
+          position: absolute;
+          left: 10%;
+          right: 10%;
+          width: 80%;
+          height: 50px;
+          margin-top: 5%; }
+          #main-container #app-container #gameplay-container #czar-blank-container #czar-blank-inner #smaller-text {
+            font-size: 18px; }
+        #main-container #app-container #gameplay-container #czar-blank-container #charity-fact-container {
+          -webkit-border-radius: 8px;
+          -moz-border-radius: 8px;
+          border-radius: 8px;
+          background-color: #fff;
+          color: black;
+          position: absolute;
+          bottom: 4%;
+          margin: 0 2%;
+          width: 96%;
+          padding: 3px;
+          text-align: left; }
+          @media (max-width: 520px) {
+            #main-container #app-container #gameplay-container #czar-blank-container #charity-fact-container {
+              height: 40%;
+              display: none; } }
+          #main-container #app-container #gameplay-container #czar-blank-container #charity-fact-container #charity-fact-tagline {
+            font-family: 'Lobster', cursive;
+            font-size: 22px;
+            margin-left: 2%;
+            margin-bottom: 3px;
+            color: #000; }
+            @media (max-width: 520px) {
+              #main-container #app-container #gameplay-container #czar-blank-container #charity-fact-container #charity-fact-tagline {
+                font-size: 16px; } }
+          #main-container #app-container #gameplay-container #czar-blank-container #charity-fact-container #charity-fact {
+            font-size: 14px;
+            font-style: italic;
+            text-align: center;
+            width: 90%;
+            margin: 0 5% 3px 5%; }
+            @media (max-width: 520px) {
+              #main-container #app-container #gameplay-container #czar-blank-container #charity-fact-container #charity-fact {
+                font-size: 12px; } }
+          @media (max-width: 520px) {
+            #main-container #app-container #gameplay-container #czar-blank-container #charity-fact-container #charity-logo-container {
+              position: absolute;
+              top: 1px;
+              right: 0; } }
+          #main-container #app-container #gameplay-container #czar-blank-container #charity-fact-container #charity-logo-container img {
+            float: right;
+            margin-right: 2%;
+            margin-bottom: 3px; }
+            @media (max-width: 520px) {
+              #main-container #app-container #gameplay-container #czar-blank-container #charity-fact-container #charity-logo-container img {
+                width: 53%; } }
+      #main-container #app-container #gameplay-container #cards-container {
+        width: 100%;
+        background: #252525;
+        margin-top: 11px;
+        -webkit-border-radius: 8px;
+        -moz-border-radius: 8px;
+        border-radius: 8px; }
+        @media (max-width: 520px) {
+          #main-container #app-container #gameplay-container #cards-container {
+            background: transparent;
+            margin-top: 2px; } }
+        #main-container #app-container #gameplay-container #cards-container #cards {
+          width: 100%;
+          height: 100%;
+          font-size: 18px;
+          padding-left: 5px; }
+          @media (max-width: 520px) {
+            #main-container #app-container #gameplay-container #cards-container #cards {
+              background: #252525;
+              -webkit-border-radius: 8px;
+              -moz-border-radius: 8px;
+              border-radius: 8px;
+              max-height: 245px; } }
 
 @media only screen and (min-width: 521px) and (max-width: 768px) {
   #notifications {
-    font-size: 18px;
-  }
-}
+    font-size: 18px; } }
+
 @media (max-width: 520px) {
   #notifications {
-    font-size: 15px;
-  }
-}
+    font-size: 15px; } }
 
 .crDonateWidget {
   -webkit-box-shadow: 0px 0px 0px 0px transparent !important;
@@ -1050,44 +842,35 @@ body {
   box-shadow: 0px 0px 0px 0px transparent !important;
   -webkit-border-radius: 8px !important;
   -moz-border-radius: 8px !important;
-  border-radius: 8px !important;
-}
+  border-radius: 8px !important; }
 
 .crDonateWidgetOuter {
   text-align: center;
   background-color: transparent !important;
-  -webkit-box-shadow: 0px 0px 0px 0px rgba(0, 0, 0, 0) !important;
-  box-shadow: 0px 0px 0px 0px rgba(0, 0, 0, 0) !important;
+  -webkit-box-shadow: 0px 0px 0px 0px transparent !important;
+  box-shadow: 0px 0px 0px 0px transparent !important;
   border: 0px solid #e6e6e6 !important;
-  margin: 0px 0px !important;
-}
+  margin: 0px 0px !important; }
 
 .crDonated {
-  margin-top: 2px !important;
-}
+  margin-top: 2px !important; }
 
 .crImageAndTitle {
-  display: none;
-}
+  display: none; }
 
 .crImageAndTitleOuter {
-  display: none;
-}
+  display: none; }
 
 .startFundraiser {
-  display: none;
-}
+  display: none; }
 
 #crDonateWidget_cfhio_cards4humanity {
   width: 90% !important;
-  margin-top: 67px !important;
-}
-#crDonateWidget_cfhio_cards4humanity .crDonateTriangle {
-  right: 6px !important;
-}
-#crDonateWidget_cfhio_cards4humanity h4 {
-  margin-bottom: 8px !important;
-}
+  margin-top: 67px !important; }
+  #crDonateWidget_cfhio_cards4humanity .crDonateTriangle {
+    right: 6px !important; }
+  #crDonateWidget_cfhio_cards4humanity h4 {
+    margin-bottom: 8px !important; }
 
 .gradientButton {
   width: 80% !important;
@@ -1096,20 +879,6 @@ body {
   -webkit-border-radius: 8px !important;
   -moz-border-radius: 8px !important;
   border-radius: 8px !important;
-  text-transform: none !important;
-}
-.gradientButton .donateNow {
-  border-top: 0px solid black !important;
-}
-
-#game-alert {
-  padding-top: 15%;
-}
-
-.invite-list {
-  background: lightgray;
-  border-radius: 2px 2px 4px 4px;
-  height: 120px;
-  overflow: scroll;
-  text-align: left;
-}
+  text-transform: none !important; }
+  .gradientButton .donateNow {
+    border-top: 0px solid black !important; }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -88,7 +88,8 @@ a {
 #charity,
 #howtoplay,
 #leaderboard,
-#warning {
+#warning,
+#loginform {
     padding-top: 12rem;
     padding-bottom: 12rem;
 }
@@ -555,4 +556,68 @@ footer {
 .text-secondary {
   color: #ed7d1a !important;
 }
+.separator {
+  margin-bottom: 30px;
+}
+.socialbuttonblock{
+  margin-top: 30px;
+}
 
+.btn-social{
+  margin-bottom: 15px;
+}
+
+.btn {
+  border-radius: 0;
+}
+
+.form-control{
+  height: 40px;
+  margin-bottom: 15px;
+  border-radius: 0;
+}
+/*
+ * Social Buttons for Bootstrap
+ *
+ * Copyright 2013-2016 Panayiotis Lipiridis
+ * Licensed under the MIT License
+ *
+ * https://github.com/lipis/bootstrap-social
+ */
+
+.btn-social{position:relative;padding-left:44px;text-align:left;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.btn-social>:first-child{position:absolute;left:0;top:0;bottom:0;width:32px;line-height:34px;font-size:1.6em;text-align:center;border-right:1px solid rgba(0,0,0,0.2)}
+.btn-social.btn-lg{padding-left:61px}.btn-social.btn-lg>:first-child{line-height:45px;width:45px;font-size:1.8em}
+.btn-social.btn-sm{padding-left:38px}.btn-social.btn-sm>:first-child{line-height:28px;width:28px;font-size:1.4em}
+.btn-social.btn-xs{padding-left:30px}.btn-social.btn-xs>:first-child{line-height:20px;width:20px;font-size:1.2em}
+.btn-social-icon{position:relative;padding-left:44px;text-align:left;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;height:34px;width:34px;padding:0}.btn-social-icon>:first-child{position:absolute;left:0;top:0;bottom:0;width:32px;line-height:34px;font-size:1.6em;text-align:center;border-right:1px solid rgba(0,0,0,0.2)}
+.btn-social-icon.btn-lg{padding-left:61px}.btn-social-icon.btn-lg>:first-child{line-height:45px;width:45px;font-size:1.8em}
+.btn-social-icon.btn-sm{padding-left:38px}.btn-social-icon.btn-sm>:first-child{line-height:28px;width:28px;font-size:1.4em}
+.btn-social-icon.btn-xs{padding-left:30px}.btn-social-icon.btn-xs>:first-child{line-height:20px;width:20px;font-size:1.2em}
+.btn-social-icon>:first-child{border:none;text-align:center;width:100% !important}
+.btn-social-icon.btn-lg{height:45px;width:45px;padding-left:0;padding-right:0}
+.btn-social-icon.btn-sm{height:30px;width:30px;padding-left:0;padding-right:0}
+.btn-social-icon.btn-xs{height:22px;width:22px;padding-left:0;padding-right:0}
+.btn-facebook{color:#fff;background-color:#3b5998;border-color:rgba(0,0,0,0.2)}.btn-facebook:focus,.btn-facebook.focus{color:#fff;background-color:#2d4373;border-color:rgba(0,0,0,0.2)}
+.btn-facebook:hover{color:#fff;background-color:#2d4373;border-color:rgba(0,0,0,0.2)}
+.btn-facebook:active,.btn-facebook.active,.open>.dropdown-toggle.btn-facebook{color:#fff;background-color:#2d4373;border-color:rgba(0,0,0,0.2)}.btn-facebook:active:hover,.btn-facebook.active:hover,.open>.dropdown-toggle.btn-facebook:hover,.btn-facebook:active:focus,.btn-facebook.active:focus,.open>.dropdown-toggle.btn-facebook:focus,.btn-facebook:active.focus,.btn-facebook.active.focus,.open>.dropdown-toggle.btn-facebook.focus{color:#fff;background-color:#23345a;border-color:rgba(0,0,0,0.2)}
+.btn-facebook:active,.btn-facebook.active,.open>.dropdown-toggle.btn-facebook{background-image:none}
+.btn-facebook.disabled:hover,.btn-facebook[disabled]:hover,fieldset[disabled] .btn-facebook:hover,.btn-facebook.disabled:focus,.btn-facebook[disabled]:focus,fieldset[disabled] .btn-facebook:focus,.btn-facebook.disabled.focus,.btn-facebook[disabled].focus,fieldset[disabled] .btn-facebook.focus{background-color:#3b5998;border-color:rgba(0,0,0,0.2)}
+.btn-facebook .badge{color:#3b5998;background-color:#fff}
+.btn-github{color:#fff;background-color:#444;border-color:rgba(0,0,0,0.2)}.btn-github:focus,.btn-github.focus{color:#fff;background-color:#2b2b2b;border-color:rgba(0,0,0,0.2)}
+.btn-github:hover{color:#fff;background-color:#2b2b2b;border-color:rgba(0,0,0,0.2)}
+.btn-github:active,.btn-github.active,.open>.dropdown-toggle.btn-github{color:#fff;background-color:#2b2b2b;border-color:rgba(0,0,0,0.2)}.btn-github:active:hover,.btn-github.active:hover,.open>.dropdown-toggle.btn-github:hover,.btn-github:active:focus,.btn-github.active:focus,.open>.dropdown-toggle.btn-github:focus,.btn-github:active.focus,.btn-github.active.focus,.open>.dropdown-toggle.btn-github.focus{color:#fff;background-color:#191919;border-color:rgba(0,0,0,0.2)}
+.btn-github:active,.btn-github.active,.open>.dropdown-toggle.btn-github{background-image:none}
+.btn-github.disabled:hover,.btn-github[disabled]:hover,fieldset[disabled] .btn-github:hover,.btn-github.disabled:focus,.btn-github[disabled]:focus,fieldset[disabled] .btn-github:focus,.btn-github.disabled.focus,.btn-github[disabled].focus,fieldset[disabled] .btn-github.focus{background-color:#444;border-color:rgba(0,0,0,0.2)}
+.btn-github .badge{color:#444;background-color:#fff}
+.btn-google{color:#fff;background-color:#dd4b39;border-color:rgba(0,0,0,0.2)}.btn-google:focus,.btn-google.focus{color:#fff;background-color:#c23321;border-color:rgba(0,0,0,0.2)}
+.btn-google:hover{color:#fff;background-color:#c23321;border-color:rgba(0,0,0,0.2)}
+.btn-google:active,.btn-google.active,.open>.dropdown-toggle.btn-google{color:#fff;background-color:#c23321;border-color:rgba(0,0,0,0.2)}.btn-google:active:hover,.btn-google.active:hover,.open>.dropdown-toggle.btn-google:hover,.btn-google:active:focus,.btn-google.active:focus,.open>.dropdown-toggle.btn-google:focus,.btn-google:active.focus,.btn-google.active.focus,.open>.dropdown-toggle.btn-google.focus{color:#fff;background-color:#a32b1c;border-color:rgba(0,0,0,0.2)}
+.btn-google:active,.btn-google.active,.open>.dropdown-toggle.btn-google{background-image:none}
+.btn-google.disabled:hover,.btn-google[disabled]:hover,fieldset[disabled] .btn-google:hover,.btn-google.disabled:focus,.btn-google[disabled]:focus,fieldset[disabled] .btn-google:focus,.btn-google.disabled.focus,.btn-google[disabled].focus,fieldset[disabled] .btn-google.focus{background-color:#dd4b39;border-color:rgba(0,0,0,0.2)}
+.btn-google .badge{color:#dd4b39;background-color:#fff}
+.btn-twitter{color:#fff;background-color:#55acee;border-color:rgba(0,0,0,0.2)}.btn-twitter:focus,.btn-twitter.focus{color:#fff;background-color:#2795e9;border-color:rgba(0,0,0,0.2)}
+.btn-twitter:hover{color:#fff;background-color:#2795e9;border-color:rgba(0,0,0,0.2)}
+.btn-twitter:active,.btn-twitter.active,.open>.dropdown-toggle.btn-twitter{color:#fff;background-color:#2795e9;border-color:rgba(0,0,0,0.2)}.btn-twitter:active:hover,.btn-twitter.active:hover,.open>.dropdown-toggle.btn-twitter:hover,.btn-twitter:active:focus,.btn-twitter.active:focus,.open>.dropdown-toggle.btn-twitter:focus,.btn-twitter:active.focus,.btn-twitter.active.focus,.open>.dropdown-toggle.btn-twitter.focus{color:#fff;background-color:#1583d7;border-color:rgba(0,0,0,0.2)}
+.btn-twitter:active,.btn-twitter.active,.open>.dropdown-toggle.btn-twitter{background-image:none}
+.btn-twitter.disabled:hover,.btn-twitter[disabled]:hover,fieldset[disabled] .btn-twitter:hover,.btn-twitter.disabled:focus,.btn-twitter[disabled]:focus,fieldset[disabled] .btn-twitter:focus,.btn-twitter.disabled.focus,.btn-twitter[disabled].focus,fieldset[disabled] .btn-twitter.focus{background-color:#55acee;border-color:rgba(0,0,0,0.2)}
+.btn-twitter .badge{color:#55acee;background-color:#fff}

--- a/public/js/controllers/index.js
+++ b/public/js/controllers/index.js
@@ -29,7 +29,7 @@ angular.module('mean.system')
   }
 
   $scope.signup = () => {
-    if (!$scope.email || !$scope.password){
+    if (!$scope.email || !$scope.password) {
       const error = { message: 'Enter your username and password' };
       $scope.showError();
       $scope.error = error;
@@ -38,7 +38,7 @@ angular.module('mean.system')
         email: $scope.email,
         password: $scope.password,
         name: $scope.name,
-        avatar: $scope.avatars.avatar
+        avatar: 0
       };
 
       // call the api
@@ -49,27 +49,19 @@ angular.module('mean.system')
           $location.path('/');
         } else {
           $scope.signupErr = 'Cannot be authenticated';
-          $scope.showError();
+          $scope.showError = () => 'invalid';
         }
       }, (err) => {
+        $scope.showError = () => 'invalid';
         $scope.signupErr = err.data.message;
-        $scope.showError();
       });
     } // if else
   };
 
   $scope.signout = () => {
     $window.localStorage.removeItem('token');
-  };
-
-  if ($window.localStorage.getItem('token')) {
-    $scope.global.authenticated = true;
-  } else {
+    $scope.showOptions = true;
     $scope.global.authenticated = false;
-  }
-
-  $scope.signout = () => {
-    $window.localStorage.removeItem('token');
     $window.user = null;
   };
 
@@ -84,10 +76,11 @@ angular.module('mean.system')
         $location.path('/');
       } else {
         $scope.showError = () => 'invalid';
+        $scope.loginError = response.data.message;
       }
     }, (err) => {
-      $scope.showError();
-      $scope.error = err;
+      $scope.showError = () => 'invalid';
+      $scope.loginError = err.data.message;
     });
   };
 }]);

--- a/public/views/index.html
+++ b/public/views/index.html
@@ -1,8 +1,8 @@
 <div landing id="main-bod">
 	<div ng-controller="IndexController">
-<!-- =========================
-     NAVIGATION LINKS     
-============================== -->
+		<!-- =========================
+				NAVIGATION LINKS     
+		============================== -->
 		<div class="navbar navbar-fixed-top top-nav-collapse custom-navbar" role="navigation">
 			<div class="container">
 
@@ -27,7 +27,7 @@
 						<li><a href="#" onClick="scroll(0,3221);">Warning</a></li>
 						<li ng-show="showOptions"><a href="#!/signin">Login</a></li>
 						<li ng-show="showOptions"><a href="#!/signup">Signup</a></li>
-						<li ng-hide="showOptions"><a href="/signout">Sign Out</a></li>
+						<li ng-hide="showOptions"><a href="/signout" ng-click="signout()">Sign Out</a></li>
 						<li><a href="https://www.crowdrise.com/donate/project/cfhio/cards4humanity/?widget=true" class="btn btn-donate">Donate Now</a></li>
 					</ul>
 

--- a/public/views/signin.html
+++ b/public/views/signin.html
@@ -1,71 +1,127 @@
-<div id="main-bod" ng-controller="IndexController">
-  <!-- Fixed Logo & Menu Bar Start -->
-  <div id="top-part">
-    <div class="wpb-top-bar">
-      <div class="mod-contain" id="navver">
+<div  id="main-bod" ng-controller="IndexController">
+	<div>
+		<!-- =========================
+				NAVIGATION LINKS     
+		============================== -->
+		<div class="navbar navbar-fixed-top top-nav-collapse custom-navbar" role="navigation">
+			<div class="container">
+
+				<!-- navbar header -->
+				<div class="navbar-header">
+					<button class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+						<span class="icon icon-bar"></span>
+						<span class="icon icon-bar"></span>
+						<span class="icon icon-bar"></span>
+					</button>
+					<a href="#" class="navbar-brand"><img src="img/logo.png" width="320" height="105" ></a>
+				</div>
+
+				<div class="collapse navbar-collapse">
+
+					<ul class="nav navbar-nav navbar-right">
+						<li><a href="#" onClick="scroll(0,0)">Home</a></li>
+						<li><a href="#" onClick="scroll(0,600);">About</a></li>
+						<li><a href="#" onClick="scroll(0,1150);">How to Play</a></li>
+						<li><a href="#" onClick="scroll(0,1811);">Leaderboard</a></li>
+						<li><a href="#" onClick="scroll(0,2491);">Charity</a></li>
+						<li><a href="#" onClick="scroll(0,3221);">Warning</a></li>
+						<li ng-show="showOptions"><a href="#!/signin">Login</a></li>
+						<li ng-show="showOptions"><a href="#!/signup">Signup</a></li>
+						<li><a href="https://www.crowdrise.com/donate/project/cfhio/cards4humanity/?widget=true" class="btn btn-donate">Donate Now</a></li>
+					</ul>
+
+				</div>
+			</div>
+		</div>
+
+    <section id="loginform" class="">
+      <div class="container">
         <div class="row">
-          <!-- Logo -->
-          <div class="wpb-logo-container">
-            <div id="landing-logo"> 
-              <span id="first-word">Cards</span>
-              <span id="second-word"> for</span> 
-              <span id="third-word">Humanity</span> 
-            </div> 
-            <div class="col-md-9 wpb-menu-container">
-              <ul class="wpb-main-menu">
-                <li><a href="/">Home</a></li>
-              </ul>
+          <!--Top header-->
+          <div class="top-header text-center">
+            <h3 class="page-title">Login</h3>
+            <div class="lead col-md-offset-2 col-md-8 col-sm-offset-1 col-sm-10">Login with your Email address or even faster with your social media account (Github, Facebook, Google or Twitter).
+						<div class="small"><br>Don't have an account. <a href="#!/signup">Click here to register</a></div>
             </div>
-          </div>      
-        </div>
-      </div>
-    </div>
-  </div>
-<!-- Fixed Logo & Menu Bar End -->
-
-<!-- Landing Start -->
-<div class="wpb-teaser parallax-background" id="homer">
-  <div class="background-opacity"></div> 
-  <div class="modified-container">
-    <div class="row" id="main-text"> 
-    <!-- Teaser Text Start -->
-    <div id="landing-logo">
-      <h2 id="slogan">Sign in with:</h2>
-      <div id="login-buttons">
-        <a href="/auth/facebook"><img class="login-item" src="/img/icons/facebook.png"></a>
-        <a href="/auth/github"><img class="login-item" src="/img/icons/github.png"></a>
-        <a href="/auth/twitter"><img class="login-item" src="/img/icons/twitter.png"></a>
-        <a href="/auth/google"><img class="login-item" src="/img/icons/google.png"></a>
-      </div>
-      <p id="create">Or log in below:</p>
-
-      <div class="sign-body">
-        <div class="more-sign">
-          <div class="sign-error" ng-show="showError() === 'invalid'" >
-            Please check your username/password and try again.
+            <div class="col-xs-12">
+              <hr class="separator">
+            </div>
+            
           </div>
-          <form class="signup form-horizontal">
-            <div class="control-group">
-              <label for="email" class="control-label"></label>
-              <div class="controls">
-                <input class="input-info" id="email" type="text" name="email" placeholder="Email" ng-model='email' required novalidate />
-              </div>
+          <!--Login via Social Media-->
+          <div class="col-sm-6">
+            <div class="col-sm-8 col-md-7 col-md-offset-4 div col-sm-offset-3 socialbuttonblock">
+              <a class="btn btn-block btn-social btn-github"  href="/auth/github">
+                <span class="fa fa-github"></span> Sign in with Github
+              </a>
+              <a class="btn btn-block btn-social btn-facebook" href="/auth/facebook">
+                <span class="fa fa-facebook"></span> Sign in with Facebook
+              </a>
+              <a class="btn btn-block btn-social btn-twitter" href="/auth/twitter">
+                <span class="fa fa-twitter"></span> Sign in with Twitter
+              </a>
+              <a class="btn btn-block btn-social btn-google" href="/auth/google">
+                <span class="fa fa-google"></span> Sign in with Google
+              </a>
             </div>
-            <div class="control-group">
-              <label for="password" class="control-label"></label>
-              <div class="controls">
-                <input class="input-info" id="password" type="password" ng-model='password' name="password" placeholder="Password" required novalidate />
-              </div>
-            </div>
-            <div class="form-actions top-margin">
-              <button id="sign-up-btn-other" ng-click='login()' >Sign In</button>
-            </div>
-          </form>
+          </div>
+          <!--Login via Email-->
+          <div class="col-sm-6">
+              <form class="form-horizontal">
+								<div class="form-group">
+									<label class="col-sm-8">Email <span class="mandatory">*</span></label>
+									<div class="col-sm-8">
+										<input type="email" name="email" id="email" value="" class="form-control" placeholder="Your Email Address" ng-model='email' required novalidate>
+									</div>
+								</div>
+
+								<div class="form-group">
+									<label label class="col-sm-8">Password <span class="mandatory">*</span></label>
+									<div class="col-sm-8">
+										<input type="password" placeholder="Password" name="password" id="password" value="" class="form-control" ng-model='password' required novalidate > 
+									</div>
+								</div>
+
+							
+								<div class="alert alert-danger col-sm-8" ng-show="showError() === 'invalid'" >
+									{{ loginError }}
+								</div>
+								<div class="form-group">
+									<div class="col-sm-12">
+										<button ng-click='login()' type="submit" class="btn btn-primary">Login</button>
+									</div>
+								</div>
+							</form>
+          </div>
+
         </div>
       </div>
-    </div>
-    </div>
-    </div>
-  </div>
-</div>
+    </section>
 
+		<!-- =========================
+			FOOTER SECTION   
+		============================== -->
+		<footer>
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-10 col-sm-offset-1 col-md-offset-2 col-md-8">
+						<p class="small">This game is based on the Cards Against Humanity card game, which is CC licensed (BY-NC-SA). Cards for Humanity is not affiliated with Cards Against Humanity. In complying with the Creative Commons license of the Cards Against Humanity card game, all proceeds from donations go directly to charity, as managed by crowdrise.</p>
+					</div>
+				</div>
+				<div class="row">
+
+					<div class="col-md-12 col-sm-12">
+
+						<p>Copyright &copy; 2017 Andela Talent Accelerator | All Rights Reserved.</p>
+
+					</div>
+					
+				</div>
+			</div>
+		</footer>
+
+
+		<!-- Back top -->
+		<a href="#back-top" class="go-top"><i class="fa fa-angle-up"></i></a>
+	</div>
+</div>

--- a/public/views/signup.html
+++ b/public/views/signup.html
@@ -1,83 +1,134 @@
-<div id="main-bod">
-  <!-- Fixed Logo & Menu Bar Start -->
-  <div id="top-part">
-    <div class="wpb-top-bar">
-      <div class="mod-contain" id="navver">
+<div landing id="main-bod">
+	<div ng-controller="IndexController">
+		<!-- =========================
+				NAVIGATION LINKS     
+		============================== -->
+		<div class="navbar navbar-fixed-top top-nav-collapse custom-navbar" role="navigation">
+			<div class="container">
+
+				<!-- navbar header -->
+				<div class="navbar-header">
+					<button class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+						<span class="icon icon-bar"></span>
+						<span class="icon icon-bar"></span>
+						<span class="icon icon-bar"></span>
+					</button>
+					<a href="#" class="navbar-brand"><img src="img/logo.png" width="320" height="105" ></a>
+				</div>
+
+				<div class="collapse navbar-collapse">
+
+					<ul class="nav navbar-nav navbar-right">
+						<li><a href="#" onClick="scroll(0,0)">Home</a></li>
+						<li><a href="#" onClick="scroll(0,600);">About</a></li>
+						<li><a href="#" onClick="scroll(0,1150);">How to Play</a></li>
+						<li><a href="#" onClick="scroll(0,1811);">Leaderboard</a></li>
+						<li><a href="#" onClick="scroll(0,2491);">Charity</a></li>
+						<li><a href="#" onClick="scroll(0,3221);">Warning</a></li>
+						<li ng-show="showOptions"><a href="#!/signin">Login</a></li>
+						<li ng-show="showOptions"><a href="#!/signup">Signup</a></li>
+						<li ng-hide="showOptions"><a href="/signout">Sign Out</a></li>
+						<li><a href="https://www.crowdrise.com/donate/project/cfhio/cards4humanity/?widget=true" class="btn btn-donate">Donate Now</a></li>
+					</ul>
+
+				</div>
+			</div>
+		</div>
+
+    <section id="loginform" class="">
+      <div class="container">
         <div class="row">
-          <!-- Logo -->
-          <div class="wpb-logo-container">
-            <div id="landing-logo"> 
-              <span id="first-word">Cards</span>
-              <span id="second-word"> for</span> 
-              <span id="third-word">Humanity</span> 
-            </div> 
-            <div class="col-md-9 wpb-menu-container">
-              <ul class="wpb-main-menu">
-                <li><a href="/">Home</a></li>
-              </ul>
+          <!--Top header-->
+          <div class="top-header text-center">
+            <h3 class="page-title">Sign Up</h3>
+            <div class="lead col-md-offset-2 col-md-8 col-sm-offset-1 col-sm-10">Signing up is as easy as ABC. Sign up with your Email address or with your social media account (Github, Facebook, Google or Twitter).
             </div>
-          </div>      
+            <div class="col-xs-12">
+              <hr class="separator">
+            </div>
+            
+          </div>
+          <!--Login via Social Media-->
+          <div class="col-sm-6">
+            <div class="col-sm-8 col-md-7 col-md-offset-4 div col-sm-offset-3 socialbuttonblock">
+              <a class="btn btn-block btn-social btn-github"  href="/auth/github">
+                <span class="fa fa-github"></span> Sign up with Github
+              </a>
+              <a class="btn btn-block btn-social btn-facebook">
+                <span class="fa fa-facebook"></span> Sign up with Facebook
+              </a>
+              <a class="btn btn-block btn-social btn-twitter">
+                <span class="fa fa-twitter"></span> Sign up with Twitter
+              </a>
+              <a class="btn btn-block btn-social btn-google">
+                <span class="fa fa-google"></span> Sign up with Google
+              </a>
+            </div>
+          </div>
+          <!--Login via Email-->
+          <div class="col-sm-6">
+            <form class="form-horizontal">
+              <div class="form-group">
+                <label class="col-sm-8">Full Name <span class="mandatory">*</span></label>
+                <div class="col-sm-8">
+                  <input type="text" name="name" id="name" value="" class="form-control" placeholder="Your Full Name" ng-model="name" required>
+                </div>
+              </div>
+
+              <div class="form-group">
+                <label class="col-sm-8">Email <span class="mandatory">*</span></label>
+                <div class="col-sm-8">
+                  <input type="text" name="email" id="email" value="" class="form-control" placeholder="Your Email Address" ng-model="email" required>
+                </div>
+              </div>
+              
+              <div class="form-group">
+                <label label class="col-sm-8">Password <span class="mandatory">*</span></label>
+                <div class="col-sm-8">
+                  <input type="password" name="name" id="name" value="" class="form-control" placeholder="Your Email Address" ng-model="password" required> 
+                </div>
+              </div>
+
+              <div class="alert alert-danger col-sm-8" ng-show="showError() === 'invalid'" >
+								{{ signupErr }}
+							</div>
+
+                <div class="form-group">
+                  <div class="col-sm-10">
+                    <button type="submit" class="btn btn-primary" ng-click="signup()">Sign Up</button>         
+                  </div>
+                </div>
+              </form>
+          </div>
+
         </div>
       </div>
-    </div>
-  </div>
-<!-- Fixed Logo & Menu Bar End -->
+    </section>
 
-<!-- Landing Start -->
-<div class="wpb-teaser parallax-background" id="homer" ng-controller="IndexController">
-  <div class="background-opacity"></div> 
-  <div class="modified-container">
-    <div class="row" id="main-text"> 
-    <!-- Teaser Text Start -->
-    <div id="landing-logo">
-      <h2 id="slogan">Sign Up with:</h2>
-      <div id="login-buttons">
-        <a href="/auth/facebook"><img class="login-item" src="/img/icons/facebook.png"></a>
-        <a href="/auth/github"><img class="login-item" src="/img/icons/github.png"></a>
-        <a href="/auth/twitter"><img class="login-item" src="/img/icons/twitter.png"></a>
-        <a href="/auth/google"><img class="login-item" src="/img/icons/google.png"></a>
-      </div>
-      <div>{{ signUpErr }}</div>
-      <p id="create">Or create a username/password and select an avatar:</p>
+		<!-- =========================
+			FOOTER SECTION   
+		============================== -->
+		<footer>
+			<div class="container">
+				<div class="row">
+					<div class="col-sm-10 col-sm-offset-1 col-md-offset-2 col-md-8">
+						<p class="small">This game is based on the Cards Against Humanity card game, which is CC licensed (BY-NC-SA). Cards for Humanity is not affiliated with Cards Against Humanity. In complying with the Creative Commons license of the Cards Against Humanity card game, all proceeds from donations go directly to charity, as managed by crowdrise.</p>
+					</div>
+				</div>
+				<div class="row">
 
-      <div class="sign-body">
-        <div class="more-sign">
-          <form class="signup form-horizontal">
-            <div class="control-group">
-              <label for="name" class="control-label"></label>
-              <div class="controls">
-                <input class="input-info" id="name" type="text" ng-model="name" name="name" placeholder="Full name" novalidate />
-              </div>
-            </div>
-            <div class="control-group">
-              <label for="email" class="control-label"></label>
-              <div class="controls">
-                <input class="input-info" id="email" type="email" ng-model="email" name="email" placeholder="Email" required novalidate />
-              </div>
-            </div>
-            <div class="control-group">
-              <label for="password" class="control-label"></label>
-              <div class="controls">
-                <input class="input-info" id="password" type="password" ng-model="password" name="password" placeholder="Password" required novalidate />
-              </div>
-            </div>
-            <div id="contain-avatars">
-              <ul class="avatar-list">
-                <li ng-repeat="avatar in avatars" class="avatars ng-scope">
-                  <input name="avatar" ng-model="avatars.avatar" type='radio' value="{{$index}}">
-                    <img ng-src="{{avatar}}">
-                  </input>
-                </li>
-              </ul>
-            </div>
-            <div class="form-actions">
-              <button id="sign-up-btn-other" ng-click="signup()" type='submit'>Sign Up</button>
-            </div>
-          </form>
-        </div>
-      </div>
-    </div>
-    </div>
-    </div>
-  </div>
+					<div class="col-md-12 col-sm-12">
+
+						<p>Copyright &copy; 2017 Andela Talent Accelerator | All Rights Reserved.</p>
+
+					</div>
+					
+				</div>
+			</div>
+		</footer>
+
+
+		<!-- Back top -->
+		<a href="#back-top" class="go-top"><i class="fa fa-angle-up"></i></a>
+	</div>
 </div>


### PR DESCRIPTION
#### What does this PR do?
Users will see a redesigned(according to material design specs and chosen color scheme) login/signup screen with the option to authenticate via facebook, twitter and google.

#### Description of Task to be completed?
The login and signup screen has been redesigned according to material design specs and chosen color scheme

#### How should this be manually tested?
After cloning the repo, run the repo locally on `localhost:3000`. Create a new user via the signup link.
 - Using Postman, test the endpoint `POST /api/auth/signup` . In the body, select `form-data` and add the values you wish to test for the keys: `name`, `email` and `password` 

#### What are the relevant pivotal tracker stories?
#143342749

#### Screenshots
<img width="1279" alt="signin cfh" src="https://user-images.githubusercontent.com/26963369/31373524-4f6ae1ae-ad92-11e7-8ae4-b6259f7bea2b.png">
